### PR TITLE
feature: inotify widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "async-stream",
  "byte-unit",
  "cnx",
+ "inotify",
  "iwlib",
  "nix 0.20.0",
  "openssl",
@@ -744,6 +745,28 @@ checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags",
+ "futures-core",
+ "inotify-sys",
+ "libc",
+ "tokio",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/cnx-contrib/Cargo.toml
+++ b/cnx-contrib/Cargo.toml
@@ -19,6 +19,7 @@ leftwm = ["process-stream", "serde", "serde_derive", "serde_json"]
 [dependencies]
 cnx = { path = "../cnx" }
 anyhow = "1.0.41"
+inotify = { version = "0.10.2", optional = true }
 weathernoaa = "0.2.0"
 tokio = { version = "1.18.0", features = ["rt", "net", "time", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.8" }

--- a/cnx-contrib/src/widgets/inotify.rs
+++ b/cnx-contrib/src/widgets/inotify.rs
@@ -1,0 +1,52 @@
+use std::fs;
+
+use cnx::{
+    text::{Attributes, Text},
+    widgets::Widget,
+};
+use inotify::WatchMask;
+use tokio_stream::StreamExt;
+
+pub struct Inotify {
+    attr: Attributes,
+    filepath: String,
+    flags: WatchMask,
+}
+
+impl Inotify {
+    pub fn new(attr: Attributes, filepath: String, flags: WatchMask) -> Self {
+        Self {
+            attr,
+            filepath,
+            flags,
+        }
+    }
+
+    fn tick(&self) -> anyhow::Result<Vec<Text>> {
+        let contents = fs::read_to_string(self.filepath.clone())?;
+        let text = contents
+            .strip_suffix("\n")
+            .unwrap_or(contents.as_str())
+            .to_string();
+        let texts = vec![Text {
+            attr: self.attr.clone(),
+            text,
+            stretch: false,
+            markup: true,
+        }];
+        Ok(texts)
+    }
+}
+
+impl Widget for Inotify {
+    fn into_stream(self: Box<Self>) -> anyhow::Result<cnx::widgets::WidgetStream> {
+        let mut inotify = inotify::Inotify::init()?;
+
+        inotify.watches().add(self.filepath.clone(), self.flags)?;
+
+        let buffer = [0; 32];
+        let stream = tokio_stream::once(self.tick())
+            .chain(inotify.into_event_stream(buffer)?.map(move |_| self.tick()));
+        Ok(Box::pin(stream))
+    }
+}

--- a/cnx-contrib/src/widgets/mod.rs
+++ b/cnx-contrib/src/widgets/mod.rs
@@ -6,6 +6,10 @@ pub mod command;
 pub mod cpu;
 /// Disk usage widget to show current usage and remaining free space
 pub mod disk_usage;
+/// Inotfiy widget to monitor files
+#[cfg(feature = "inotify")]
+#[cfg_attr(docsrs, doc(cfg(feature = "inotify")))]
+pub mod inotify;
 /// LeftWM widget that subscribes to leftwm-state and streams the monitors and tags upfate
 #[cfg(feature = "leftwm")]
 #[cfg_attr(docsrs, doc(cfg(feature = "leftwm")))]


### PR DESCRIPTION
Watching the contents of files is an effective way to manage custom modules that don't warrant their own implementation of `Widget`. With inotify, the kernel can be leveraged to do this efficiently (without polling).
